### PR TITLE
Only save the transformed output file if it's different from the original input file

### DIFF
--- a/XmlTransform/XmlTransform.nuspec
+++ b/XmlTransform/XmlTransform.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>XmlTransform</id>
-    <version>1.0.0.0</version>
+    <version>1.0.1.0</version>
     <title>XmlTransform utitlity</title>
     <authors>Maciej Nowak</authors>
     <owners>Maciej Nowak</owners>    


### PR DESCRIPTION
We had IIS process reset issues when web.config was touched even if there were no changes.
